### PR TITLE
Better handling of close states for QueryResult consumers

### DIFF
--- a/spiffy.go
+++ b/spiffy.go
@@ -524,7 +524,8 @@ func (q *QueryResult) OutMany(collection interface{}) error {
 
 	sliceType := reflectType(collection)
 	if sliceType.Kind() != reflect.Slice {
-		return exception.New("Destination collection is not a slice.")
+		q.Error = exception.New("Destination collection is not a slice.")
+		return q.Close()
 	}
 
 	sliceInnerType := reflectSliceType(collection)
@@ -562,7 +563,8 @@ func (q *QueryResult) Each(consumer RowsConsumer) error {
 	for q.Rows.Next() {
 		err = consumer(q.Rows)
 		if err != nil {
-			return err
+			q.Error = err
+			return q.Close()
 		}
 	}
 


### PR DESCRIPTION
We are missing a couple calls to Close() for returns.