### PR TITLE
Further hardens spiffy methods with better error handling

### DIFF
--- a/spiffy.go
+++ b/spiffy.go
@@ -402,7 +402,7 @@ func (q *QueryResult) Close() error {
 		q.Stmt = nil
 	}
 
-	return exception.WrapMany(q.Error, rowsErr, stmtErr)
+	return exception.WrapMany(rowsErr, stmtErr)
 }
 
 // Any returns if there are any results for the query.

--- a/spiffy.go
+++ b/spiffy.go
@@ -1078,7 +1078,8 @@ func (dbAlias *DbConnection) CreateInTransaction(object DatabaseMapped, tx *sql.
 	if len(serials.Columns) == 0 {
 		_, execErr := stmt.Exec(colValues...)
 		if execErr != nil {
-			return exception.Wrap(execErr)
+			err = exception.Wrap(execErr)
+			return
 		}
 	} else {
 		serial := serials.Columns[0]
@@ -1086,11 +1087,13 @@ func (dbAlias *DbConnection) CreateInTransaction(object DatabaseMapped, tx *sql.
 		var id interface{}
 		execErr := stmt.QueryRow(colValues...).Scan(&id)
 		if execErr != nil {
-			return exception.Wrap(execErr)
+			err = exception.Wrap(execErr)
+			return
 		}
 		setErr := serial.SetValue(object, id)
 		if setErr != nil {
-			return exception.Wrap(setErr)
+			err = exception.Wrap(setErr)
+			return
 		}
 	}
 
@@ -1132,7 +1135,8 @@ func (dbAlias *DbConnection) UpdateInTransaction(object DatabaseMapped, tx *sql.
 
 	stmt, stmtErr := dbAlias.Prepare(sqlStmt, tx)
 	if stmtErr != nil {
-		return exception.Wrap(stmtErr)
+		err = exception.Wrap(stmtErr)
+		return
 	}
 	defer func() {
 		closeErr := stmt.Close()

--- a/spiffy.go
+++ b/spiffy.go
@@ -873,7 +873,6 @@ func (dbAlias *DbConnection) QueryInTransaction(statement string, tx *sql.Tx, ar
 		result.Error = exception.Wrap(stmtErr)
 		return
 	}
-
 	defer func() {
 		if r := recover(); r != nil {
 			closeErr := stmt.Close()
@@ -883,7 +882,7 @@ func (dbAlias *DbConnection) QueryInTransaction(statement string, tx *sql.Tx, ar
 
 	rows, queryErr := stmt.Query(args...)
 	if queryErr != nil {
-		result.Error = queryErr
+		result.Error = exception.Wrap(queryErr)
 		return
 	}
 


### PR DESCRIPTION
In an attempt to better capture where and how shared transaction errors are being created, I'm being more diligent about how we handle errors. 